### PR TITLE
Added minor QOL sign-in changes

### DIFF
--- a/src/routes/auth/login/LoginForm.svelte
+++ b/src/routes/auth/login/LoginForm.svelte
@@ -57,11 +57,11 @@
           <h3 class="text-xl font-medium text-gray-900 p-0">Login</h3>
           <Label class="space-y-2">
             <span>Your email</span>
-            <Input bind:value={email} type="email" name="email" placeholder="name@company.com" required />
+            <Input bind:value={email} type="email" name="email" placeholder="Enter @cpsd.us email" required />
           </Label>
           <Label class="space-y-2">
             <span>Your password</span>
-            <Input bind:value={password} type="password" name="password" placeholder="•••••" required />
+            <Input bind:value={password} type="password" name="password" placeholder="Enter password" required />
           </Label>
           <div class="flex items-start">
             <Checkbox>Remember me</Checkbox>
@@ -85,7 +85,6 @@
         </form>
         {#if $errorMessage.length > 1}
           <Alert color="red">
-            <span class="font-medium">Login failed:</span>
             {$errorMessage}
           </Alert>
         {/if}

--- a/src/routes/auth/login/forgotpassword/+page.svelte
+++ b/src/routes/auth/login/forgotpassword/+page.svelte
@@ -40,7 +40,7 @@
         <h3 class="text-xl font-medium text-gray-900 p-0">Password Reset</h3>
         <Label class="space-y-2">
           <span>Your email</span>
-          <Input bind:value={email} type="email" name="email" placeholder="name@company.com" required />
+          <Input bind:value={email} type="email" name="email" placeholder="Enter @cpsd.us email" required />
         </Label>
         <Button color="green" type="submit" class="w-full1">
           Submit
@@ -51,7 +51,6 @@
       </form>
       {#if $errorMessage.length > 1}
         <Alert color="red">
-          <span class="font-medium">Password reset failed:</span>
           {$errorMessage}
         </Alert>
       {/if}

--- a/src/routes/auth/signup/SignupForm.svelte
+++ b/src/routes/auth/signup/SignupForm.svelte
@@ -101,15 +101,15 @@
               <h3 class="text-xl font-medium text-gray-900 p-0">Sign up</h3>
               <Label class="space-y-2">
                   <span>Your email</span>
-                  <Input bind:value={email} name="email" id="email" placeholder="name@cpsd.us" required/>
+                  <Input bind:value={email} name="email" id="email" placeholder="Enter @cpsd.us email" required/>
               </Label>
               <Label class="space-y-2">
                   <span>Your password</span>
-                  <Input bind:value={password} type="password" name="password" id="password" placeholder="•••••" required/>
+                  <Input bind:value={password} type="password" name="password" id="password" placeholder="Enter password" required/>
               </Label>
               <Label class="space-y-2">
                   <span>Confirm password</span>
-                  <Input bind:value={confirmPassword} type="password" name="confirmpassword" placeholder="•••••" required/>
+                  <Input bind:value={confirmPassword} type="password" name="confirmpassword" placeholder="Enter password" required/>
               </Label>
               <Button color="green" type="submit" class="w-full1">
                 Sign Up
@@ -120,7 +120,6 @@
           </form>
           {#if $errorMessage.length > 1}
             <Alert color="red">
-              <span class="font-medium">Signup failed:</span>
               {$errorMessage}
             </Alert>
           {/if}


### PR DESCRIPTION
- Changed login placeholders to more standardized versions (ie. ••••• to "Enter password") and made it more clear that  a cpsd email is required<br>
![Screenshot from 2024-10-26 15-34-01](https://github.com/user-attachments/assets/8ef65753-b247-420a-ac09-a0a3bf6598e8) to ![Screenshot from 2024-10-26 15-34-16](https://github.com/user-attachments/assets/db42de80-ce43-46f2-b0a6-225a875c2ae2)
<br>

- Removed "Signup failed:" and "Login failed:" precursors so that it just displays the error/issue with fields

![Screenshot from 2024-10-26 15-31-05](https://github.com/user-attachments/assets/a5d975b5-4574-4549-8921-39f486569583) to ![Screenshot from 2024-10-26 15-30-04](https://github.com/user-attachments/assets/5987ea86-5405-490e-9773-435a274577ba)

Let me know if you dislike these changes, or something else that could improve them.